### PR TITLE
OTC-1080: added check to skip legacy test for postgresql

### DIFF
--- a/payment/tests.py
+++ b/payment/tests.py
@@ -20,6 +20,7 @@ from product.test_helpers import create_test_product, create_test_product_servic
 # noinspection DuplicatedCode
 class PaymentServiceTestCase(TestCase):
     def test_call_to_legacy(self):
+        # TODO: Add matching test and procedure for PostgreSQL
         if not connection.vendor == 'mssql':
             self.skipTest("This test can only be executed for MSSQL database")
         officer = create_test_officer(custom_props={"code": "TSTSIMP1"})

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -20,40 +20,41 @@ from product.test_helpers import create_test_product, create_test_product_servic
 # noinspection DuplicatedCode
 class PaymentServiceTestCase(TestCase):
     def test_call_to_legacy(self):
-        if connection.vendor == 'mssql':
-            officer = create_test_officer(custom_props={"code": "TSTSIMP1"})
-            insuree = create_test_insuree(custom_props={"chf_id": "paysimp"})
-            product = create_test_product("ELI1")
-            (policy, insuree_policy) = create_test_policy2(product, insuree, custom_props={
-                "value": 1000, "status": Policy.STATUS_IDLE})
-            service = create_test_service("A")
-            svc_pl_detail = add_service_to_hf_pricelist(service)
-            product_service = create_test_product_service(product, service, custom_props={"limit_no_adult": 20})
-            premium = create_test_premium(policy_id=policy.id, with_payer=False)
-            payment, payment_detail = create_test_payment2(
-                insuree_code=insuree.chf_id,
-                product_code=product.code,
-                officer_code=officer.code,
-            )
+        if not connection.vendor == 'mssql':
+            self.skipTest("This test can only be executed for MSSQL database")
+        officer = create_test_officer(custom_props={"code": "TSTSIMP1"})
+        insuree = create_test_insuree(custom_props={"chf_id": "paysimp"})
+        product = create_test_product("ELI1")
+        (policy, insuree_policy) = create_test_policy2(product, insuree, custom_props={
+            "value": 1000, "status": Policy.STATUS_IDLE})
+        service = create_test_service("A")
+        svc_pl_detail = add_service_to_hf_pricelist(service)
+        product_service = create_test_product_service(product, service, custom_props={"limit_no_adult": 20})
+        premium = create_test_premium(policy_id=policy.id, with_payer=False)
+        payment, payment_detail = create_test_payment2(
+            insuree_code=insuree.chf_id,
+            product_code=product.code,
+            officer_code=officer.code,
+        )
 
-            legacy_match_payment(payment.id, -1)
-            #errors = validate_payment_detail(payment_detail)
+        legacy_match_payment(payment.id, -1)
+        #errors = validate_payment_detail(payment_detail)
 
-            payment_detail.refresh_from_db()
-            policy.refresh_from_db()
-            self.assertIsNotNone(payment_detail.premium)
-            self.assertEqual(payment_detail.premium, premium)
+        payment_detail.refresh_from_db()
+        policy.refresh_from_db()
+        self.assertIsNotNone(payment_detail.premium)
+        self.assertEqual(payment_detail.premium, premium)
 
-            payment_detail.delete()
-            payment.delete()
-            premium.delete()
-            product_service.delete()
-            svc_pl_detail.delete()
-            service.delete()
-            policy.insuree_policies.all().delete()
-            policy.delete()
-            product.delete()
-            officer.delete()
+        payment_detail.delete()
+        payment.delete()
+        premium.delete()
+        product_service.delete()
+        svc_pl_detail.delete()
+        service.delete()
+        policy.insuree_policies.all().delete()
+        policy.delete()
+        product.delete()
+        officer.delete()
 
     def test_validate_simple(self):
         officer = create_test_officer(custom_props={"code": "TSTSIMP1"})


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-1080

Changes:
- added check for database type because it tried to execute mssql code and procedure which doesn't exist in pssql. Test is skipped when test is different than mssql